### PR TITLE
Title fix

### DIFF
--- a/adafruit_clue.py
+++ b/adafruit_clue.py
@@ -106,7 +106,7 @@ class _ClueSimpleTextDisplay:
                                 scale=title_scale)
             title.x = 0
             title.y = 8
-            self._y = title.y + 15
+            self._y = title.y + 18
 
             self.text_group.append(title)
         else:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,3 +6,7 @@ Ensure your device works with this simple test.
 .. literalinclude:: ../examples/clue_simpletest.py
     :caption: examples/clue_simpletest.py
     :linenos:
+
+.. literalinclude:: ../examples/clue_display_sensor_data.py
+    :caption: examples/clue_display_sensor_data.py
+    :linenos:

--- a/examples/clue_display_sensor_data.py
+++ b/examples/clue_display_sensor_data.py
@@ -2,7 +2,7 @@ from adafruit_clue import clue
 
 clue.sea_level_pressure = 1020
 
-clue_data = clue.simple_text_display(title="CLUE Sensor Data!", title_scale=2, num_lines=15)
+clue_data = clue.simple_text_display(title="CLUE Sensor Data!", title_scale=2)
 
 while True:
     clue_data[0].text = "Acceleration: {:.2f} {:.2f} {:.2f} m/s^2".format(*clue.acceleration)


### PR DESCRIPTION
As per request, now defaults to no title. Title can be specified, color set, and text scaled separately still, but defaults to None. 

Lines of text are now automatically created and appended if listed in the code, so number of lines no longer needs to be specified. This avoids the errors if the number of text lines exceeded the number of lines identified in setup. 