### PR TITLE
Added clue_ams_remote.py

### DIFF
--- a/examples/advanced_examples/clue_ams_remote_advanced.py
+++ b/examples/advanced_examples/clue_ams_remote_advanced.py
@@ -12,6 +12,7 @@ adafruit_display_text
 """
 
 import time
+import board
 import adafruit_ble
 from adafruit_ble.advertising.standard import SolicitServicesAdvertisement
 from adafruit_ble_apple_media import AppleMediaService
@@ -21,7 +22,7 @@ import displayio
 from adafruit_bitmap_font import bitmap_font
 from adafruit_display_shapes.rect import Rect
 from adafruit_display_text import label
-import board
+
 
 # PyLint can't find BLERadio for some reason so special case it here.
 radio = adafruit_ble.BLERadio() # pylint: disable=no-member
@@ -73,10 +74,10 @@ track_time = Rect(15, 210, 210, 20, fill=0x0, outline=0xFFFFFF)
 #time = label.Label(font=arial16, x=15, y=215, text='Time', color=0xFFFFFF)
 group.append(track_time)
 
-time_inner = Rect(15, 210, 1, 20, fill=0xFFFFFF, outline=0xFFFFFF) 
+time_inner = Rect(15, 210, 1, 20, fill=0xFFFFFF, outline=0xFFFFFF)
 group.append(time_inner)
 
-volume_inner = Rect(15, 170, 1, 20, fill=0xFFFFFF, outline=0xFFFFFF) 
+volume_inner = Rect(15, 170, 1, 20, fill=0xFFFFFF, outline=0xFFFFFF)
 group.append(volume_inner)
 
 display.show(group)

--- a/examples/advanced_examples/clue_ams_remote_advanced.py
+++ b/examples/advanced_examples/clue_ams_remote_advanced.py
@@ -5,7 +5,6 @@ and capacitive touch pads.
 This example requires the following additional libraries:
 adafruit_ble
 adafruit_ble_apple_media
-displayio
 adafruit_bitmap_font
 adafruit_display_shapes
 adafruit_display_text

--- a/examples/clue_ams_remote.py
+++ b/examples/clue_ams_remote.py
@@ -1,6 +1,7 @@
 """
 This example solicits that apple devices that provide notifications connect to it, initiates
-pairing, prints existing notifications and then prints any new ones as they arrive.
+pairing, then allows the user to use a CLUE board as a media remote through both the buttons
+and capacitive touch pads.
 """
 
 import time
@@ -33,10 +34,10 @@ if radio.connected:
 
 while radio.connected:
     if ams.playing:
-        play = "Playing"
+        play_str = "Playing"
     else:
-        play = "Paused"
-    print("{} - {},  {}".format(ams.title, ams.artist, play))
+        play_str = "Paused"
+    print("{} - {},  {}".format(ams.title, ams.artist, play_str))
 
     # Capacitive touch pad marked 0 goes to the previous track
     if clue.touch_0:

--- a/examples/clue_ams_remote.py
+++ b/examples/clue_ams_remote.py
@@ -30,7 +30,7 @@ if radio.connected:
             print("paired")
 
         ams = connection[AppleMediaService]
-        
+
 while radio.connected:
     if ams.playing:
         play = "Playing"

--- a/examples/clue_ams_remote.py
+++ b/examples/clue_ams_remote.py
@@ -2,6 +2,10 @@
 This example solicits that apple devices that provide notifications connect to it, initiates
 pairing, then allows the user to use a CLUE board as a media remote through both the buttons
 and capacitive touch pads.
+
+This example requires the following additional libraries:
+adafruit_ble
+adafruit_ble_apple_media
 """
 
 import time

--- a/examples/clue_ams_remote.py
+++ b/examples/clue_ams_remote.py
@@ -1,0 +1,72 @@
+"""
+This example solicits that apple devices that provide notifications connect to it, initiates
+pairing, prints existing notifications and then prints any new ones as they arrive.
+"""
+
+import time
+import adafruit_ble
+from adafruit_ble.advertising.standard import SolicitServicesAdvertisement
+from adafruit_ble_apple_media import AppleMediaService
+from adafruit_clue import clue
+
+# PyLint can't find BLERadio for some reason so special case it here.
+radio = adafruit_ble.BLERadio() # pylint: disable=no-member
+a = SolicitServicesAdvertisement()
+a.solicited_services.append(AppleMediaService)
+radio.start_advertising(a)
+
+while not radio.connected:
+    pass
+
+print("connected")
+
+known_notifications = set()
+
+i = 0
+if radio.connected:
+    for connection in radio.connections:
+        if not connection.paired:
+            connection.pair()
+            print("paired")
+
+        ams = connection[AppleMediaService]
+        
+while radio.connected:
+    if ams.playing:
+        play = "Playing"
+    else:
+        play = "Paused"
+    print("{} - {},  {}".format(ams.title, ams.artist, play))
+
+    # Capacitive touch pad marked 0 goes to the previous track
+    if clue.touch_0:
+        ams.previous_track()
+        time.sleep(0.25)
+
+    # Capacitive touch pad marked 1 toggles pause/play
+    if clue.touch_1:
+        ams.toggle_play_pause()
+        time.sleep(0.25)
+
+    # Capacitive touch pad marked 2 advances to the next track
+    if clue.touch_2:
+        ams.next_track()
+        time.sleep(0.25)
+
+    # If button B (on the right) is pressed, it increases the volume
+    if 'B' in clue.were_pressed:
+        ams.volume_up()
+        time.sleep(0.30)
+        while 'B' in clue.were_pressed:
+            ams.volume_up()
+            time.sleep(0.07)
+
+    # If button A (on the left) is pressed, the volume decreases
+    if 'A' in clue.were_pressed:
+        ams.volume_down()
+        time.sleep(0.30)
+        while 'A' in clue.were_pressed:
+            ams.volume_down()
+            time.sleep(0.07)
+
+print("disconnected")


### PR DESCRIPTION
Was experimenting with using buttons and capacitive touch as a remote using ams to add to pyloton. I thought the test code I wrote could be quite useful, so I'm PRing it. Didn't really want to add displayio to keep it simple and increase responsiveness, although adding that wouldn't take a whole lot of time to do.