### PR TITLE
Update proximity

### DIFF
--- a/adafruit_clue.py
+++ b/adafruit_clue.py
@@ -468,11 +468,7 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
               print("Proximity: {}".format(clue.proximity))
         """
         self._sensor.enable_proximity = True
-        try:
-            prox = self._sensor.proximity()
-        except TypeError:
-            prox = self._sensor.proximity
-        return prox
+        return self._sensor.proximity
 
     @property
     def color(self):

--- a/adafruit_clue.py
+++ b/adafruit_clue.py
@@ -468,7 +468,11 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
               print("Proximity: {}".format(clue.proximity))
         """
         self._sensor.enable_proximity = True
-        return self._sensor.proximity()
+        try:
+            prox = self._sensor.proximity()
+        except TypeError:
+            prox = self._sensor.proximity
+        return prox
 
     @property
     def color(self):


### PR DESCRIPTION
Update to work with new version of APDS9960 library, for this release:
https://github.com/adafruit/Adafruit_CircuitPython_APDS9960/releases/tag/2.0.0

```python
Adafruit CircuitPython 5.0.0 on 2020-03-02; Adafruit CLUE nRF52840 Express with nRF52840
>>> from adafruit_clue import clue
>>> clue.proximity
0
>>> clue.proximity
135
>>> 
```