### PR TITLE
Introduce delay to allow REPL to stop code execution

### DIFF
--- a/examples/clue_spirit_level.py
+++ b/examples/clue_spirit_level.py
@@ -1,6 +1,6 @@
 """CLUE Spirit Level Demo"""
-import board
 import time
+import board
 from adafruit_clue import clue
 from adafruit_display_shapes.circle import Circle
 import displayio

--- a/examples/clue_spirit_level.py
+++ b/examples/clue_spirit_level.py
@@ -1,5 +1,6 @@
 """CLUE Spirit Level Demo"""
 import board
+import time
 from adafruit_clue import clue
 from adafruit_display_shapes.circle import Circle
 import displayio
@@ -26,3 +27,4 @@ while True:
     x, y, _ = clue.acceleration
     bubble_group.x = int(x * -10)
     bubble_group.y = int(y * -10)
+    time.sleep(0.05)  # 50ms delay to allow REPL to stop execution


### PR DESCRIPTION
A delay is needed in the primary loop so that the example code execution can be immediately stopped from the REPL. The delay also allows the file system to be accessed when the code is running. This was successfully tested with 5.3.0, the 20200502 library bundle, and Mu 1.0.1 / Windows 10 pro.