### PR TITLE
Fixed minor formatting in docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         source actions-ci/install.sh
     - name: Pip install pylint, Sphinx, pre-commit
       run: |
-        pip install --force-reinstall pylint Sphinx sphinx-rtd-theme pre-commit
+        pip install --force-reinstall pylint==2.6.* Sphinx sphinx-rtd-theme pre-commit
     - name: Library version
       run: git describe --dirty --always --tags
     - name: Pre-commit hooks
@@ -53,8 +53,7 @@ jobs:
     - name: PyLint
       run: |
         pylint $( find . -path './adafruit*.py' )
-        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -name "advanced_examples" -prune -false -o -path "./examples/*.py" ))
-        ([[ ! -d "examples/advanced_examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/advanced_examples/*.py" ))
+        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*.py" ))
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,8 @@ jobs:
     - name: PyLint
       run: |
         pylint $( find . -path './adafruit*.py' )
-        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*.py" ))
+        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -name "advanced_examples" -prune -false -o -path "./examples/*.py" ))
+        ([[ ! -d "examples/advanced_examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/advanced_examples/*.py" ))
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles

--- a/adafruit_clue.py
+++ b/adafruit_clue.py
@@ -960,5 +960,5 @@ clue = Clue()  # pylint: disable=invalid-name
 
    .. code-block:: python
 
-   from adafruit_clue import clue
+     from adafruit_clue import clue
 """


### PR DESCRIPTION
I wanted to fix a minor issue in the docs where a code block in a comment did not completely enclose the sample code. Along the way I also ended up dealing with an issue where PyLint found too many duplicate lines of code between clue_ams_remote.py and clue_ams_remote_advanced.py.