### PR TITLE
Remove max_size parameter

### DIFF
--- a/adafruit_clue.py
+++ b/adafruit_clue.py
@@ -100,7 +100,7 @@ class _ClueSimpleTextDisplay:
         if font:
             self._font = font
 
-        self.text_group = displayio.Group(max_size=20, scale=text_scale)
+        self.text_group = displayio.Group(scale=text_scale)
 
         if title:
             # Fail gracefully if title is longer than 60 characters.

--- a/examples/advanced_examples/clue_ams_remote_advanced.py
+++ b/examples/advanced_examples/clue_ams_remote_advanced.py
@@ -54,7 +54,7 @@ arial16 = bitmap_font.load_font("/fonts/Arial-16.bdf")
 
 display = board.DISPLAY
 
-group = displayio.Group(max_size=25)
+group = displayio.Group()
 
 title = label.Label(font=arial16, x=15, y=25, text="_", color=0xFFFFFF, max_glyphs=30)
 group.append(title)

--- a/examples/clue_ble_color_patchwork.py
+++ b/examples/clue_ble_color_patchwork.py
@@ -137,10 +137,10 @@ for _i, _color in enumerate(color_options):
     color_select_palette[_i] = _color
 
 # Color Select Layout
-color_select_group = displayio.Group(max_size=10)
-color_select_text_group = displayio.Group(max_size=4, scale=3)
+color_select_group = displayio.Group()
+color_select_text_group = displayio.Group(scale=3)
 
-# white backrground
+# white background
 background = Rect(0, 0, 240, 240, fill=0xFFFFFF)
 center_line = Rect(119, 0, 2, 180, fill=0x000000)
 

--- a/examples/clue_spirit_level.py
+++ b/examples/clue_spirit_level.py
@@ -8,7 +8,7 @@ from adafruit_display_shapes.circle import Circle
 from adafruit_clue import clue
 
 display = board.DISPLAY
-clue_group = displayio.Group(max_size=4)
+clue_group = displayio.Group()
 
 outer_circle = Circle(120, 120, 119, outline=clue.WHITE)
 middle_circle = Circle(120, 120, 75, outline=clue.YELLOW)
@@ -18,7 +18,7 @@ clue_group.append(middle_circle)
 clue_group.append(inner_circle)
 
 x, y, _ = clue.acceleration
-bubble_group = displayio.Group(max_size=1)
+bubble_group = displayio.Group()
 level_bubble = Circle(int(x + 120), int(y + 120), 20, fill=clue.RED, outline=clue.RED)
 bubble_group.append(level_bubble)
 


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a CLUE to test with.