### PR TITLE
updating_advanced_example

### DIFF
--- a/examples/advanced_examples/clue_ams_remote_advanced.py
+++ b/examples/advanced_examples/clue_ams_remote_advanced.py
@@ -10,6 +10,9 @@ adafruit_ble_apple_media
 adafruit_bitmap_font
 adafruit_display_shapes
 adafruit_display_text
+
+This example requires a lot of memory resources, make sure that you use
+the mpy version of the libraries
 """
 
 import time


### PR DESCRIPTION
This will add a note to use the `.mpy` version of the libraries, as PR removing the max_size in displayio caused a memory error using libraries `.py` versions.