### PR TITLE
Remove usage of max_glyphs with Label

### DIFF
--- a/adafruit_clue.py
+++ b/adafruit_clue.py
@@ -110,7 +110,6 @@ class _ClueSimpleTextDisplay:
             title = label.Label(
                 self._font,
                 text=title,
-                max_glyphs=60,
                 color=title_color,
                 scale=title_scale,
             )
@@ -137,7 +136,7 @@ class _ClueSimpleTextDisplay:
 
     def add_text_line(self, color=0xFFFFFF):
         """Adds a line on the display of the specified color and returns the label object."""
-        text_label = self._label.Label(self._font, text="", max_glyphs=45, color=color)
+        text_label = self._label.Label(self._font, text="", color=color)
         text_label.x = 0
         text_label.y = self._y
         self._y = text_label.y + 13

--- a/examples/advanced_examples/clue_ams_remote_advanced.py
+++ b/examples/advanced_examples/clue_ams_remote_advanced.py
@@ -59,16 +59,16 @@ display = board.DISPLAY
 
 group = displayio.Group()
 
-title = label.Label(font=arial16, x=15, y=25, text="_", color=0xFFFFFF, max_glyphs=30)
+title = label.Label(font=arial16, x=15, y=25, text="_", color=0xFFFFFF)
 group.append(title)
 
-artist = label.Label(font=arial16, x=15, y=50, text="_", color=0xFFFFFF, max_glyphs=30)
+artist = label.Label(font=arial16, x=15, y=50, text="_", color=0xFFFFFF)
 group.append(artist)
 
-album = label.Label(font=arial16, x=15, y=75, text="_", color=0xFFFFFF, max_glyphs=30)
+album = label.Label(font=arial16, x=15, y=75, text="_", color=0xFFFFFF)
 group.append(album)
 
-player = label.Label(font=arial16, x=15, y=100, text="_", color=0xFFFFFF, max_glyphs=30)
+player = label.Label(font=arial16, x=15, y=100, text="_", color=0xFFFFFF)
 group.append(player)
 
 volume = Rect(15, 170, 210, 20, fill=0x0, outline=0xFFFFFF)


### PR DESCRIPTION
Remove usage of `max_glyphs` now that it has been removed from `Adafruit_CircuitPython_Display_Text`
https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/releases/tag/2.20.0

**Not tested** - I don't have a CLUE