### PR TITLE
removing use of gamepad

### DIFF
--- a/adafruit_clue.py
+++ b/adafruit_clue.py
@@ -53,7 +53,6 @@ import adafruit_sht31d
 import audiobusio
 import audiopwmio
 import audiocore
-import gamepad
 import touchio
 
 __version__ = "0.0.0-auto.0"
@@ -197,7 +196,6 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
         self._a.switch_to_input(pull=digitalio.Pull.UP)
         self._b = digitalio.DigitalInOut(board.BUTTON_B)
         self._b.switch_to_input(pull=digitalio.Pull.UP)
-        self._gamepad = gamepad.GamePad(self._a, self._b)
 
         # Define LEDs:
         self._white_leds = digitalio.DigitalInOut(board.WHITE_LEDS)
@@ -349,29 +347,6 @@ class Clue:  # pylint: disable=too-many-instance-attributes, too-many-public-met
                   print("Button B pressed")
         """
         return not self._b.value
-
-    @property
-    def were_pressed(self):
-        """Returns a set of the buttons that have been pressed.
-
-        .. image :: ../docs/_static/button_b.jpg
-          :alt: Button B
-
-        To use with the CLUE:
-
-        .. code-block:: python
-
-          from adafruit_clue import clue
-
-          while True:
-              print(clue.were_pressed)
-        """
-        ret = set()
-        pressed = self._gamepad.get_pressed()
-        for button, mask in (("A", 0x01), ("B", 0x02)):
-            if mask & pressed:
-                ret.add(button)
-        return ret
 
     def shake(self, shake_threshold=30, avg_count=10, total_delay=0.1):
         """

--- a/examples/advanced_examples/clue_ams_remote_advanced.py
+++ b/examples/advanced_examples/clue_ams_remote_advanced.py
@@ -136,20 +136,18 @@ while radio.connected:
             time.sleep(0.25)
 
         # If button B (on the right) is pressed, it increases the volume
-        if "B" in clue.were_pressed:
+        if clue.button_b:
             ams.volume_up()
-            a = clue.were_pressed
             time.sleep(0.35)
-            while "B" in clue.were_pressed:
+            while clue.button_b:
                 ams.volume_up()
                 time.sleep(0.07)
 
         # If button A (on the left) is pressed, the volume decreases
-        if "A" in clue.were_pressed:
+        if clue.button_a:
             ams.volume_down()
-            a = clue.were_pressed
             time.sleep(0.35)
-            while "A" in clue.were_pressed:
+            while clue.button_a:
                 ams.volume_down()
                 time.sleep(0.07)
         time.sleep(0.01)

--- a/examples/clue_ams_remote.py
+++ b/examples/clue_ams_remote.py
@@ -62,18 +62,18 @@ while radio.connected:
         time.sleep(0.25)
 
     # If button B (on the right) is pressed, it increases the volume
-    if "B" in clue.were_pressed:
+    if clue.button_b:
         ams.volume_up()
         time.sleep(0.30)
-        while "B" in clue.were_pressed:
+        while clue.button_b:
             ams.volume_up()
             time.sleep(0.07)
 
     # If button A (on the left) is pressed, the volume decreases
-    if "A" in clue.were_pressed:
+    if clue.button_a:
         ams.volume_down()
         time.sleep(0.30)
-        while "A" in clue.were_pressed:
+        while clue.button_a:
             ams.volume_down()
             time.sleep(0.07)
 


### PR DESCRIPTION
_**This is a breaking change! We will need to bump the major version if/when it's merged and released.**_

This removes the use of `gamepad` from the library which has been removed from the CircuitPython core (ref [#4940](https://github.com/adafruit/circuitpython/pull/4940)). The only thing that this library used it for was the `were_pressed` API. This PR removes the `were_pressed` property and updates the relevant examples to use `clue.button_a` and `clue.button_b` instead of `were_pressed`

While working on this I also removed the lines in the advanced ams example like this one:
```
a = clue.were_pressed
```
It seems to me these were accidental / unnecessary. The only other use of the `a` variable is before the main loop starts and was for the BLE advertisement rather than anything related to buttons. Nothing else in the main loop seemed to be accessing this value after it was being set based on the button value.

I do not have an Apple media device to test the updated examples with, but I did test out that section of the code on a CLUE with CircuitPython `7.0.0-alpha.5` by running this minimal example that uses the same logic. Everything appears to be working as intended.
```python
from adafruit_clue import clue
import time

while True:
    # If button B (on the right) is pressed, it increases the volume
    if clue.button_b:
        print("inital vol up")
        time.sleep(0.30)
        while clue.button_b:
            time.sleep(0.07)

    # If button A (on the left) is pressed, the volume decreases
    if clue.button_a:
        print("inital vol down")
        time.sleep(0.30)
        while clue.button_a:
            print("vol down")
            time.sleep(0.07)
```